### PR TITLE
[FIX] singularity build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # 
 #     https://github.com/kaczmarj/neurodocker
 
-FROM hbclab/accel-bids
+FROM hbclab/accel-bids:unstable
 
 USER root
 

--- a/Dockerfile_exec
+++ b/Dockerfile_exec
@@ -3,6 +3,19 @@ FROM ubuntu:18.04
 
 USER root
 
+ENV ND_ENTRYPOINT="/neurodocker/startup.sh"
+
+RUN export ND_ENTRYPOINT="/neurodocker/startup.sh" \
+    && mkdir -p /neurodocker \
+    && if [ ! -f "$ND_ENTRYPOINT" ]; then \
+         echo '#!/usr/bin/env bash' >> "$ND_ENTRYPOINT" \
+    &&   echo 'set -e' >> "$ND_ENTRYPOINT" \
+    &&   echo 'export USER="${USER:=`whoami`}"' >> "$ND_ENTRYPOINT" \
+    &&   echo 'source activate accel' >> "$ND_ENTRYPOINT" \
+    &&   echo 'if [ -n "$1" ]; then "$@"; else /usr/bin/env bash; fi' >> "$ND_ENTRYPOINT"; \
+    fi \
+    && chmod -R 777 /neurodocker && chmod a+s /neurodocker
+
 # Get base utilities
 RUN apt-get update \
     && apt-get -y install curl \
@@ -11,14 +24,15 @@ RUN apt-get update \
 # Conda install
 ENV PATH="/opt/miniconda-latest/bin:$PATH"
 
+RUN useradd --create-home --shell /bin/bash coder
+USER coder
+
 RUN export PATH="/opt/miniconda-latest/bin:$PATH" \
     && conda_installer="/tmp/miniconda.sh" \
     && curl -fsSL --retry 5 -o "$conda_installer" https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
     && bash "$conda_installer" -b -p /opt/miniconda-latest
 
 
-RUN useradd --create-home --shell /bin/bash coder
-USER coder
 RUN mkdir /home/coder/projects
 WORKDIR /home/coder/projects
 
@@ -29,4 +43,4 @@ RUN conda env create -f environment.yml
 RUN bash -c 'conda init && . /home/coder/.bashrc && . activate accel && pip install -e /home/coder/projects'
 
 # Run as executable
-ENTRYPOINT ["conda", "run", "-n", "accel", "python", "/home/coder/projects/accel_code/run.py"]
+ENTRYPOINT ["/neurodocker/startup.sh", "accel_transform"]

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,10 @@
 from setuptools import setup, find_packages
 
-setup(name="accel-code", packages=find_packages())
+setup(
+    name="accel-code", packages=find_packages(),
+    entry_points={
+        "console_scripts": [
+            "accel_transform = accel_code.run:main",
+        ],
+    },
+)


### PR DESCRIPTION
- create a console entry point (commandline tool) from the package
- run a starter file from within the container (appears to be most robust/least disruptive way to activate a conda environment at run-time)
- install miniconda as user 