### PR TITLE
[ENH] ensure there is a log entry for every run

### DIFF
--- a/accel_code/run.py
+++ b/accel_code/run.py
@@ -105,6 +105,8 @@ def main():
 
     if file_copied:
         logger.info("{of} -> {nf}".format(of=opts.old_file_path, nf=new_file_path))
+    else:
+        logger.info("{of} already copied".format(of=opts.old_file_path))
 
     return
 


### PR DESCRIPTION
This ensures the log-html code has a log message to separate the entries from each other.